### PR TITLE
Setup README and hide API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,82 @@
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+## Playgrounds
+timeline.xctimeline
+playground.xcworkspace
+
+# Swift Package Manager
+#
+# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
+# Packages/
+# Package.resolved
+# .build/
+
+# CocoaPods
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# Pods/
+#
+# Add this line if you want to avoid checking in build files from CocoaPods.
+# Podfile.lock
+
+# Carthage
+#
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# fastlane
+#
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+#
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+# Secrets
+FoodApp/Secrets.plist

--- a/FoodApp/ContentView.swift
+++ b/FoodApp/ContentView.swift
@@ -36,7 +36,7 @@ struct NewRecipe: Encodable {
 struct ContentView: View {
 
     // API Keys
-    let apiKey = "AIzaSyCe_0Eclyu2g9PvzFDN--3VQl-yrY_QKHw"
+    let apiKey = Secrets.geminiAPIKey
     let supabase = FoodApp.supabase
 
     // Preferences

--- a/FoodApp/FoodAppApp.swift
+++ b/FoodApp/FoodAppApp.swift
@@ -13,8 +13,8 @@ struct FoodApp: App {
     
     // 1. Supabase Kurulumu
     static let supabase = SupabaseClient(
-        supabaseURL: URL(string: "https://lnbpezkgrtwmlmxlfxwr.supabase.co")!,
-        supabaseKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImxuYnBlemtncnR3bWxteGxmeHdyIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjEzMDUxNDUsImV4cCI6MjA3Njg4MTE0NX0.lvjDJusQnagn1yqFZdPwkuIqjmpXKXnADpSaitzAdJo"
+        supabaseURL: Secrets.supabaseURL,
+        supabaseKey: Secrets.supabaseAnonKey
     )
     
     // 2. AuthManager (Senkron başlatılıyor)

--- a/FoodApp/Secrets-Template.plist
+++ b/FoodApp/Secrets-Template.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>GeminiAPIKey</key>
+    <string>YOUR_GEMINI_API_KEY_HERE</string>
+    <key>SupabaseURL</key>
+    <string>YOUR_SUPABASE_URL_HERE</string>
+    <key>SupabaseAnonKey</key>
+    <string>YOUR_SUPABASE_ANON_KEY_HERE</string>
+</dict>
+</plist>

--- a/FoodApp/Secrets.swift
+++ b/FoodApp/Secrets.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum Secrets {
+    private static var secrets: [String: Any]? {
+        guard let url = Bundle.main.url(forResource: "Secrets", withExtension: "plist"),
+              let data = try? Data(contentsOf: url),
+              let dict = try? PropertyListSerialization.propertyList(from: data, options: [], format: nil) as? [String: Any] else {
+            return nil
+        }
+        return dict
+    }
+
+    static var geminiAPIKey: String {
+        return secrets?["GeminiAPIKey"] as? String ?? ""
+    }
+
+    static var supabaseURL: URL {
+        let urlString = secrets?["SupabaseURL"] as? String ?? ""
+        return URL(string: urlString) ?? URL(string: "https://example.com")!
+    }
+
+    static var supabaseAnonKey: String {
+        return secrets?["SupabaseAnonKey"] as? String ?? ""
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# FoodApp
+
+## Türkçe (Turkish)
+FoodApp, kullanıcıların diyet tercihlerine, ellerindeki malzemelere veya yemek fotoğraflarına göre yemek tarifleri oluşturmasına ve kaydetmesine yardımcı olan, SwiftUI ile geliştirilmiş bir iOS uygulamasıdır. Kullanıcı girdilerinden ve fotoğraflarından yapay zeka destekli tarifler üretmek için **Google Gemini AI** kullanır. Kullanıcı girişi (Authentication) ve tarif veritabanı (Database) işlemleri için ise **Supabase** altyapısını kullanmaktadır.
+
+### Özellikler
+- Malzeme veya yemek fotoğrafı ile yapay zeka destekli tarif oluşturma.
+- Vegan, vejetaryen ve glütensiz gibi diyet tercihlerine uygun filtreleme.
+- İstenmeyen malzemeleri hariç tutma ve pişirme süresine göre tarif önerme.
+- Tariflerin Supabase veritabanına kaydedilmesi ve kullanıcı profili yönetimi.
+
+## English
+FoodApp is a SwiftUI-based iOS application that helps users generate and save recipes based on their dietary preferences, available ingredients, or photos of food. It utilizes **Google Gemini AI** to generate AI-powered recipes from user text prompts and images. For user authentication and recipe database management, it integrates with **Supabase**.
+
+### Features
+- AI-powered recipe generation using ingredients or food photos.
+- Filtering based on dietary preferences such as vegan, vegetarian, and gluten-free.
+- Excluding unwanted ingredients and getting recommendations based on prep time.
+- Saving generated recipes to a Supabase database and user profile management.
+
+---
+
+### Setup Instructions / Kurulum Talimatları
+1. Clone the repository.
+2. In order to run the app, you need to provide your own API keys.
+3. Create a `Secrets.plist` file in the `FoodApp` folder with the following keys:
+   - `GeminiAPIKey` (String)
+   - `SupabaseURL` (String)
+   - `SupabaseAnonKey` (String)
+4. Build and run the project using Xcode.


### PR DESCRIPTION
Setup project README, hide API keys and configure ignore file

- Added English and Turkish README descriptions
- Created Secrets-Template.plist and a Secrets.swift utility wrapper
- Extracted hardcoded Gemini and Supabase keys from ContentView.swift and FoodAppApp.swift
- Added a standard Xcode .gitignore, specifically excluding Secrets.plist

---
*PR created automatically by Jules for task [4701531063255586438](https://jules.google.com/task/4701531063255586438) started by @emircanozer*